### PR TITLE
Fix: "msg": "No package matching 'kong_dependencies' is available"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
 
 - name: Install dependencies
   apt: pkg={{ item }} state=installed
-  with_items: kong_dependencies
+  with_items: "{{ kong_dependencies }}"
 
 - name: Install deb
   apt: deb={{ kong_working_dir }}/kong.deb


### PR DESCRIPTION
TASK [ansible-role-kong : Install dependencies] ********************************
failed: [kong] (item=[u'kong_dependencies']) => {"failed": true, "item": ["kong_dependencies"], "msg": "No package matching 'kong_dependencies' is available"}